### PR TITLE
Added matchBuilder option in EasyRichTextPattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,3 +71,6 @@
 
 ## [0.5.2] - 2020-10-11
 * Special characters
+
+## [0.5.3] - 2020-11-23
+* Added matchBuilder option in EasyRichTextPattern

--- a/lib/src/easy_rich_text_pattern.dart
+++ b/lib/src/easy_rich_text_pattern.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 
+typedef EasyRichTextMatchBuilder = InlineSpan Function(BuildContext context, RegExpMatch match);
+
 class EasyRichTextPattern {
   ///target string that you want to format
   final String targetString;
@@ -50,11 +52,13 @@ class EasyRichTextPattern {
   ///defalut match all
   final dynamic matchOption;
 
+  final EasyRichTextMatchBuilder matchBuilder;
+
   EasyRichTextPattern({
     Key key,
     @required this.targetString,
-    this.stringBeforeTarget = "",
-    this.stringAfterTarget = "",
+    this.stringBeforeTarget = '',
+    this.stringAfterTarget = '',
     this.matchWordBoundaries = true,
     this.matchLeftWordBoundary = true,
     this.matchRightWordBoundary = true,
@@ -65,6 +69,7 @@ class EasyRichTextPattern {
     this.recognizer,
     this.hasSpecialCharacters = false,
     this.matchOption = 'all',
+    this.matchBuilder,
   });
 
   EasyRichTextPattern copyWith({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: easy_rich_text
 description: The EasyRichText widget provides an easy way to use RichText. You do not have to split the string manually.
-version: 0.5.2
+version: 0.5.3
 homepage: https://github.com/2000calories/flutter_easy_rich_text
 
 environment:


### PR DESCRIPTION
Can be used for example in my specific case to replace pattern string `***[string]***` with highlighted `string`.

```dart
                  EasyRichTextPattern(
                    targetString: RegExp(r'\*{3}\[(.+?)\]\*{3}'),
                    matchBuilder: (BuildContext context, RegExpMatch match) {
                      return TextSpan(
                        text: match[1],
                        style: _questionTextHighlightMissesStyle,
                      );
                    },
                  ),
```