### PR TITLE
remove print statements from production code

### DIFF
--- a/lib/src/easy_rich_text.dart
+++ b/lib/src/easy_rich_text.dart
@@ -99,8 +99,6 @@ class EasyRichText extends StatelessWidget {
     String url = str;
     if (await canLaunch(url)) {
       await launch(url);
-    } else {
-      print('Could not launch $url');
     }
   }
 
@@ -215,7 +213,6 @@ class EasyRichText extends StatelessWidget {
       RegExp exp = new RegExp(thisRegExPattern,
           caseSensitive: caseSensitive, unicode: unicode);
       var allMatches = exp.allMatches(temText);
-      print(thisRegExPattern);
 
       //check matchOption ['all','first','last', 0, 1, 2, 3, 10]
 
@@ -293,7 +290,6 @@ class EasyRichText extends StatelessWidget {
             .add(temText.substring(splitPositions[index - 1], splitPosition));
       }
     });
-    print(strList);
     return strList;
   }
 
@@ -351,7 +347,6 @@ class EasyRichText extends StatelessWidget {
       var inlineSpan;
       int targetIndex = -1;
       RegExpMatch? match;
-      print(finalTempPatternList2);
       if (tempPatternList != null) {
         finalTempPatternList2.asMap().forEach((index, pattern) {
           String targetString = pattern.targetString;
@@ -364,8 +359,6 @@ class EasyRichText extends StatelessWidget {
           );
 
           RegExpMatch? tempMatch = targetStringExp.firstMatch(str);
-          print(str);
-          print(match);
           if (tempMatch is RegExpMatch) {
             targetIndex = index;
             match = tempMatch;


### PR DESCRIPTION
remove print statements from production code - they add a lot of noise into consuming code test runs and needlessly pollute the console while running apps in the simulator