### PR TITLE
iOS can now also dial phone numbers containing empty spaces.

### DIFF
--- a/lib/src/easy_rich_text.dart
+++ b/lib/src/easy_rich_text.dart
@@ -128,7 +128,8 @@ class EasyRichText extends StatelessWidget {
       case 'tel':
         tapGestureRecognizer = TapGestureRecognizer()
           ..onTap = () {
-            _launchURL("tel:$str");
+            _launchURL("tel:${str.replaceAll(' ', '')}");
+	    // In order to recognize the number, iOS requires no empty spaces.
           };
         break;
       default:


### PR DESCRIPTION
Phone numbers containing white spaces – such as `+41 78 000 00` – were recognized, but it was not possible to dial them from iPhone (only from Android). This has been addressed.