### PR TITLE
iOS can now dial phone numbers at the end of any line.

### DIFF
--- a/lib/src/patterns.dart
+++ b/lib/src/patterns.dart
@@ -7,5 +7,5 @@ class EasyRegexPattern {
       //(?!(\/EMAILPATTERN\/))
       //ingore domain from email
       '(http(s)?:\\/\\/.)?(www\\.)?[-a-zA-Z0-9:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)';
-  static String telPattern = "[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[-\\s/0-9]{5,11}";
+  static String telPattern = "[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[ -/0-9]{5,11}";
 }


### PR DESCRIPTION
This change enables iOS users to have the phone number automatically dialed when they tap on a telephone number.

Previously, the phone number was recognized, but it was not able to get it automatically dialed.

The regex expression was slightly changed. With the change, only an empty space can be added between blocks of digits. I think it makes more sense now, because a phone number's blocks of digits should not be separated by `\n`, `\t`, or multiple empty spaces. This definitely fixes the iOS bug.

The fix was also tested on Android (which was not affected by the bug).

The documentation may need some changes.