### PR TITLE
Add default EasyRichTextPatterns for bold and italics

### DIFF
--- a/lib/easy_rich_text.dart
+++ b/lib/easy_rich_text.dart
@@ -2,4 +2,5 @@ library easy_rich_text;
 
 export 'src/easy_rich_text.dart';
 export 'src/easy_rich_text_pattern.dart';
+export 'src/easy_rich_text_patterns.dart';
 export 'src/patterns.dart';

--- a/lib/src/easy_rich_text_patterns.dart
+++ b/lib/src/easy_rich_text_patterns.dart
@@ -1,8 +1,11 @@
-import 'package:easy_rich_text/src/easy_rich_text_pattern.dart';
-import 'package:easy_rich_text/src/patterns.dart';
 import 'package:flutter/widgets.dart';
 
-abstract class EasyRichTextPatterns {
+import 'easy_rich_text_pattern.dart';
+import 'patterns.dart';
+
+class EasyRichTextPatterns {
+  EasyRichTextPatterns._();
+
   static final bold = EasyRichTextPattern(
     targetString: EasyRegexPattern.boldPattern,
     matchWordBoundaries: false,

--- a/lib/src/easy_rich_text_patterns.dart
+++ b/lib/src/easy_rich_text_patterns.dart
@@ -1,0 +1,31 @@
+import 'package:easy_rich_text/src/easy_rich_text_pattern.dart';
+import 'package:easy_rich_text/src/patterns.dart';
+import 'package:flutter/widgets.dart';
+
+abstract class EasyRichTextPatterns {
+  static final bold = EasyRichTextPattern(
+    targetString: EasyRegexPattern.boldPattern,
+    matchWordBoundaries: false,
+    matchBuilder: (context, match) {
+      return TextSpan(
+        text: match?[0]?.substring(1, match[0]!.length - 1),
+        style: const TextStyle(
+          fontWeight: FontWeight.bold,
+        ),
+      );
+    },
+  );
+
+  static final italic = EasyRichTextPattern(
+    targetString: EasyRegexPattern.italicPattern,
+    matchWordBoundaries: false,
+    matchBuilder: (context, match) {
+      return TextSpan(
+        text: match?[0]?.substring(1, match[0]!.length - 1),
+        style: const TextStyle(
+          fontStyle: FontStyle.italic,
+        ),
+      );
+    },
+  );
+}

--- a/lib/src/patterns.dart
+++ b/lib/src/patterns.dart
@@ -1,11 +1,13 @@
 library patterns;
 
 class EasyRegexPattern {
-  static String emailPattern =
+  static const emailPattern =
       '\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}\\b';
-  static String webPattern =
+  static const webPattern =
       //(?!(\/EMAILPATTERN\/))
-      //ingore domain from email
+      //ignore domain from email
       '(http(s)?:\\/\\/.)?(www\\.)?[-a-zA-Z0-9:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)';
-  static String telPattern = "[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[ -/0-9]{5,11}";
+  static const telPattern = "[+]*[(]{0,1}[0-9]{1,4}[)]{0,1}[ -/0-9]{5,11}";
+  static const boldPattern = '(\\*)(.*?)(\\*)';
+  static const italicPattern = '(_)(.*?)(_)';
 }


### PR DESCRIPTION
Hey @2000calories - thanks for your work on this plugin 🙏 

This PR adds two default/pre-built EasyRichTextPatterns for bold (when text is surrounded with `*asterisks*`) and italics (when text is surrounded by `_underscores_`).

Can be used like this:

```
EasyRichText(
  "TEST *bold font*. test *boldfont*. TEST _italicised_. test _italics_.",
  patternList: [
    EasyRichTextPatterns.bold,
    EasyRichTextPatterns.italic,
  ],
),
```

Closes #56 

