### PR TITLE
Allow easier extension of EasyRichText widgets

### DIFF
--- a/lib/src/easy_rich_text.dart
+++ b/lib/src/easy_rich_text.dart
@@ -1,5 +1,5 @@
-import 'dart:ui';
 import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle;
+import 'dart:ui';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -605,13 +605,16 @@ class EasyRichText extends StatelessWidget {
       finalTempPatternList2: finalTempPatternList2,
     );
 
+    return buildTextWidget(context, textSpanList);
+  }
+
+  Widget buildTextWidget(BuildContext context, List<InlineSpan> textSpans) {
     if (selectable) {
       return SelectableText.rich(
         TextSpan(
-            style: defaultStyle == null
-                ? DefaultTextStyle.of(context).style
-                : defaultStyle,
-            children: textSpanList),
+          style: defaultStyle ?? DefaultTextStyle.of(context).style,
+          children: textSpans,
+        ),
         scrollPhysics: scrollPhysics,
         contextMenuBuilder: contextMenuBuilder,
         maxLines: maxLines,
@@ -641,10 +644,9 @@ class EasyRichText extends StatelessWidget {
     } else {
       return Text.rich(
         TextSpan(
-            style: defaultStyle == null
-                ? DefaultTextStyle.of(context).style
-                : defaultStyle,
-            children: textSpanList),
+          style: defaultStyle ?? DefaultTextStyle.of(context).style,
+          children: textSpans,
+        ),
         locale: locale,
         maxLines: maxLines,
         overflow: overflow,


### PR DESCRIPTION
Hi @2000calories 👋 

I have a use case where I need to integrate `AutoSizeText` with `EasyRichText`. I appreciate that not all users of this package will need that, so I didn't think it necessary to add [AutoSizeText](https://pub.dev/packages/auto_size_text) as a dependency for the whole package.

I did however make a change that makes it easier to extend EasyRichText widgets by creating a new method which is only responsible for building the widget.

For my example, with this change I was able to use this in my app to build an `AutoSizeEasyRichText` widget with very little boilerplate code:

```
import 'package:auto_size_text/auto_size_text.dart';
import 'package:easy_rich_text/easy_rich_text.dart';
import 'package:flutter/widgets.dart';

 class AutoSizeEasyRichText extends EasyRichText {
  AutoSizeEasyRichText(
    super.text, {
    super.key,
    super.defaultStyle,
    super.textAlign,
    super.maxLines,
    super.patternList,
    this.minFontSize,
  });

  final double? minFontSize;

  @override
  Widget buildTextWidget(BuildContext context, List<InlineSpan> textSpans) {
    return AutoSizeText.rich(
      TextSpan(
        style: defaultStyle ?? DefaultTextStyle.of(context).style,
        children: textSpans,
      ),
      locale: locale,
      minFontSize: minFontSize ?? 1,
      maxLines: maxLines,
      overflow: overflow,
      softWrap: softWrap,
      strutStyle: strutStyle,
      textAlign: textAlign,
      textDirection: textDirection,
    );
  }
}
```
